### PR TITLE
Use Streamlit secrets for OpenAI keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ git clone <your‑repo‑url>
 cd secure-rd-assistant
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-cp config/config_template.py config/config.py   # add your keys
+cp config/config_template.py config/config.py   # optional fallback
 streamlit run app.py
+```
+
+Add your OpenAI key(s) to `.streamlit/secrets.toml` as:
+
+```toml
+openai_api_keys = ["sk-...", "sk-..."]
 ```
 
 Open your browser at `http://localhost:8501`, enter a project description

--- a/config/config_template.py
+++ b/config/config_template.py
@@ -1,6 +1,4 @@
 
-# Copy this file to config.py and fill in your real OpenAI keys.
-OPENAI_API_KEYS = [
-    "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",
-    "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"
-]
+# Optional fallback list of API keys used if Streamlit secrets are not provided.
+# On Streamlit Cloud, define ``openai_api_keys`` in ``secrets.toml`` instead.
+OPENAI_API_KEYS = []

--- a/modules/router.py
+++ b/modules/router.py
@@ -1,5 +1,6 @@
 
 import random
+import streamlit as st
 
 try:
     import openai
@@ -7,21 +8,33 @@ except ModuleNotFoundError as e:
     openai = None
 
 try:
-    from config.config import OPENAI_API_KEYS  # user-provided keys
+    from config.config import OPENAI_API_KEYS as LOCAL_KEYS  # user-provided keys
 except ImportError:
     try:
-        from config.config_template import OPENAI_API_KEYS  # placeholder list (empty)
+        from config.config_template import OPENAI_API_KEYS as LOCAL_KEYS  # placeholder list (empty)
     except ImportError:
-        OPENAI_API_KEYS = []
+        LOCAL_KEYS = []
+
+def _load_api_keys() -> list:
+    """Return API keys from Streamlit secrets or fallback config."""
+    keys = st.secrets.get("openai_api_keys")
+    if isinstance(keys, str):
+        keys = [k.strip() for k in keys.split(',') if k.strip()]
+    if isinstance(keys, list) and keys:
+        return list(keys)
+    return LOCAL_KEYS
 
 class QueryRouter:
     """Rotate through API keys (and optionally proxies) for each outbound query."""
+
     def __init__(self):
         if openai is None:
             raise ModuleNotFoundError("The 'openai' package is required but not installed.")
-        if not OPENAI_API_KEYS:
-            raise RuntimeError("No OpenAI API keys found. Please populate config/config.py.")
-        self.api_keys = OPENAI_API_KEYS
+        self.api_keys = _load_api_keys()
+        if not self.api_keys:
+            raise RuntimeError(
+                "No OpenAI API keys found. Add them to Streamlit secrets or config/config.py."
+            )
         self.key_index = random.randrange(len(self.api_keys))
 
     def ask(self, prompt: str, domain: str) -> str:


### PR DESCRIPTION
## Summary
- pull OpenAI API keys from `st.secrets` when available
- document how to configure secrets in README
- provide empty fallback list in `config_template.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `streamlit run app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9a28e7c0832c97f67cc795b0da3b