### PR TITLE
Enable offline mode without libpango

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ export OPENAI_API_KEYS="sk-1,sk-2"        # comma separated list
 Open your browser at `http://localhost:8501`, enter a project description
 (e.g. "Design a drone for wildfire detection") and click **Run Secure Research**.
 A PDF report will be generated for download once the loop completes.
+
+### Running offline
+
+If your environment lacks system packages such as `libpango` required by
+WeasyPrint, the application will automatically fall back to a pure Python
+solution using `fpdf` for PDF generation. Install the Python dependencies from
+`requirements.txt` using locally available wheels and run `streamlit run app.py`
+as described above. No internet connection is needed at runtime.

--- a/modules/composer.py
+++ b/modules/composer.py
@@ -1,8 +1,34 @@
 from markdown2 import markdown
-from weasyprint import HTML
+
+try:  # Prefer weasyprint if system deps are available
+    from weasyprint import HTML
+    _USE_WEASYPRINT = True
+except Exception:  # pragma: no cover - fallback when libpango is missing
+    from fpdf import FPDF
+    _USE_WEASYPRINT = False
+
+
+def _make_pdf_fpdf(html: str) -> bytes:
+    """Create a minimal PDF from HTML using FPDF.
+
+    The HTML is converted to plain text line by line. This avoids external
+    dependencies so the application can run in offline environments.
+    """
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.set_font("Arial", size=12)
+    for line in html.splitlines():
+        text = line.strip()
+        if text:
+            pdf.multi_cell(0, 10, txt=text)
+        else:
+            pdf.ln(5)
+    return pdf.output(dest="S").encode("latin-1")
 
 
 def make_pdf(report_md: str) -> bytes:
     html = markdown(report_md)
-    pdf_bytes = HTML(string=html).write_pdf()
-    return pdf_bytes
+    if _USE_WEASYPRINT:
+        return HTML(string=html).write_pdf()
+    return _make_pdf_fpdf(html)


### PR DESCRIPTION
## Summary
- avoid weasyprint dependency when libpango isn't installed
- generate PDF with fpdf as a fallback
- document how to run the app offline without libpango

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba21d4d04832c992e22ec0dc2a59f