### PR TITLE
Fix dictionary mutation bug during summary pass

### DIFF
--- a/modules/orchestrator.py
+++ b/modules/orchestrator.py
@@ -40,7 +40,7 @@ def run_research(request: str):
 
     # --- summary pass ---
     summary_log = []
-    for domain, answer in results.items():
+    for domain, answer in list(results.items()):
         summary_prompt = (
             f"Summarize the following text in 3–4 crisp bullet points:\n\n{answer}"
         )


### PR DESCRIPTION
## Summary
- prevent `run_research` from mutating `results` while iterating

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ba2e48888832c85dd6cc4b87c1468