### PR TITLE
Add FPDF fallback for missing WeasyPrint libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ A PDF report will be generated for download once the loop completes.
 ### Running offline
 
 If your environment lacks system packages such as `libpango` required by
-WeasyPrint, the application will automatically fall back to a pure Python
-solution using `fpdf` for PDF generation. Install the Python dependencies from
-`requirements.txt` using locally available wheels and run `streamlit run app.py`
-as described above. No internet connection is needed at runtime.
+WeasyPrint or if the library fails to load, the application automatically
+falls back to a pure Python solution using `fpdf` for PDF generation.
+Install the Python dependencies from `requirements.txt` using locally available
+wheels and run `streamlit run app.py` as described above. No internet connection
+is needed at runtime.

--- a/modules/composer.py
+++ b/modules/composer.py
@@ -1,12 +1,39 @@
 from markdown2 import markdown
-from weasyprint import HTML, CSS
 
-STYLE = CSS(string="""
+try:
+    from weasyprint import HTML, CSS
+    _WEASYPRINT_AVAILABLE = True
+except Exception:  # missing system deps like libpango
+    from fpdf import FPDF
+    _WEASYPRINT_AVAILABLE = False
+
+STYLE = None
+if _WEASYPRINT_AVAILABLE:
+    STYLE = CSS(string="""
 h1 { text-align:center; }
 h2 { page-break-before:always; }
 li { margin-bottom:4px; }
 """)
 
-def make_pdf(markdown_text: str) -> bytes:
-    html = markdown(markdown_text)
+def _make_pdf_weasy(html: str) -> bytes:
+    """Generate a PDF using WeasyPrint if available."""
     return HTML(string=html).write_pdf(stylesheets=[STYLE])
+
+
+def _make_pdf_fpdf(markdown_text: str) -> bytes:
+    """Simplistic fallback PDF generator using FPDF."""
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.set_font("Arial", size=12)
+    for line in markdown_text.splitlines():
+        pdf.multi_cell(0, 10, line)
+    return bytes(pdf.output(dest="S"))
+
+
+def make_pdf(markdown_text: str) -> bytes:
+    """Convert markdown text to PDF using WeasyPrint or FPDF."""
+    html = markdown(markdown_text)
+    if _WEASYPRINT_AVAILABLE:
+        return _make_pdf_weasy(html)
+    return _make_pdf_fpdf(markdown_text)


### PR DESCRIPTION
## Summary
- make composer fall back to FPDF when WeasyPrint dependencies are missing
- clarify README about the automatic fallback behavior

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685babdf7644832c9bcda79e677af424