### PR TITLE
Handle Unicode in FPDF fallback

### DIFF
--- a/modules/composer.py
+++ b/modules/composer.py
@@ -1,4 +1,5 @@
 from markdown2 import markdown
+import unicodedata
 
 try:
     from weasyprint import HTML, CSS
@@ -27,7 +28,8 @@ def _make_pdf_fpdf(markdown_text: str) -> bytes:
     pdf.set_auto_page_break(auto=True, margin=15)
     pdf.set_font("Arial", size=12)
     for line in markdown_text.splitlines():
-        pdf.multi_cell(0, 10, line)
+        safe_line = unicodedata.normalize("NFKD", line).encode("latin-1", "replace").decode("latin-1")
+        pdf.multi_cell(0, 10, safe_line)
     return bytes(pdf.output(dest="S"))
 
 


### PR DESCRIPTION
## Summary
- avoid UnicodeEncodeError when weasyprint is unavailable
- normalize text lines so that `fpdf` can handle them

## Testing
- `python -m py_compile modules/composer.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_685bae81f3b0832ca7a6272d0db0a02d