### PR TITLE
Fix FPDF pdf.output encoding

### DIFF
--- a/modules/composer.py
+++ b/modules/composer.py
@@ -28,9 +28,13 @@ def _make_pdf_fpdf(markdown_text: str) -> bytes:
     pdf.set_auto_page_break(auto=True, margin=15)
     pdf.set_font("Arial", size=12)
     for line in markdown_text.splitlines():
-        safe_line = unicodedata.normalize("NFKD", line).encode("latin-1", "replace").decode("latin-1")
+        safe_line = (
+            unicodedata.normalize("NFKD", line)
+            .encode("latin-1", "replace")
+            .decode("latin-1")
+        )
         pdf.multi_cell(0, 10, safe_line)
-    return bytes(pdf.output(dest="S"))
+    return pdf.output(dest="S").encode("latin-1")
 
 
 def make_pdf(markdown_text: str) -> bytes:


### PR DESCRIPTION
## Summary
- avoid TypeError when converting FPDF output to bytes by explicitly encoding

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bb049974c832cb7d7a6a64cde1a7f