### PR TITLE
Add OpenAI function-calling support

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "orchestrator",
     "synthesizer",
     "composer",
+    "tools",
 ]
 
 import importlib

--- a/modules/tools.py
+++ b/modules/tools.py
@@ -1,0 +1,28 @@
+"""Utility functions accessible via OpenAI function calling."""
+
+from __future__ import annotations
+
+from typing import List
+
+
+def semantic_search(query: str) -> str:
+    """Mock semantic search returning a simple string for the query."""
+    return f"Results for '{query}' from the knowledge base."
+
+
+def fetch_image(query: str) -> str:
+    """Return a fake image URL for the given query."""
+    safe = query.strip().replace(" ", "_")
+    return f"https://example.com/images/{safe}.png"
+
+
+def summarize_text(text: str, sentences: int = 2) -> str:
+    """Return the first few sentences of the text as a naive summary."""
+    if sentences <= 0:
+        return ""
+    # Split by sentence terminators for simplicity
+    import re
+
+    parts = re.split(r"(?<=[.!?]) +", text)
+    summary = " ".join(parts[:sentences])
+    return summary.strip()


### PR DESCRIPTION
## Summary
- create a simple `tools` module with mock helper functions
- expose the new tools submodule
- update `QueryRouter` to support OpenAI function calling
  - register tool functions and schemas
  - dispatch calls via a new `call_tool` method
  - loop on function calls in `ask`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6dabd77c832cbbc6699be93b250f